### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "pygame"
+run = "python3 main.py"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # GameEngine
-
+[![Run on Repl.it](https://repl.it/badge/github/Her02N0one/GameEngine)](https://repl.it/github/Her02N0one/GameEngine)
 A python game engine written by Ayden Mitchell.
+


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@AydenMitchell/GameEngine-1).